### PR TITLE
[V2 Rust] Create release workflow for native binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_name: buildc-linux-x64
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact_name: buildc-linux-arm64
+          # - target: aarch64-unknown-linux-gnu
+          #   os: ubuntu-latest
+          #   artifact_name: buildc-linux-arm64
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
           - target: x86_64-pc-windows-gnu
             os: windows-latest
             artifact_name: buildc-windows-x64.exe
-          - target: i686-pc-windows-gnu
-            os: windows-latest
-            artifact_name: buildc-windows-x86.exe
+          # - target: i686-pc-windows-gnu
+          #   os: windows-latest
+          #   artifact_name: buildc-windows-x86.exe
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact_name: buildc-macos-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,24 +14,26 @@ jobs:
     strategy:
       matrix:
         include:
+          # Windows x86_64
           - target: x86_64-pc-windows-gnu
             os: windows-latest
             artifact_name: buildc-windows-x64.exe
-          # - target: i686-pc-windows-gnu
-          #   os: windows-latest
-          #   artifact_name: buildc-windows-x86.exe
+          # Windows arm64
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            artifact_name: buildc-windows-arm64.exe
+          # MacOS x86_64
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact_name: buildc-macos-x64
+          # MacOS arm64
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact_name: buildc-macos-arm64
+          # Linux x86_64
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_name: buildc-linux-x64
-          # - target: aarch64-unknown-linux-gnu
-          #   os: ubuntu-latest
-          #   artifact_name: buildc-linux-arm64
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+on:
+  workflow_dispatch:
+
+jobs:
+  # draft-release:
+  #   runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            os: windows-latest
+            artifact_name: buildc-windows-x64.exe
+          - target: i686-pc-windows-gnu
+            os: windows-latest
+            artifact_name: buildc-windows-x86.exe
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact_name: buildc-macos-x64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact_name: buildc-macos-arm64
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact_name: buildc-linux-x64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact_name: buildc-linux-arm64
+    steps:
+      # Checkout and pull changes from previous jobs
+      - uses: actions/checkout@v4
+      - run: git pull
+      # Setup
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      # Build
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Rename buildc (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir dist
+          mv target/${{ matrix.target }}/release/buildc.exe dist/${{ matrix.artifact_name }}
+        shell: bash
+      - name: Rename buildc (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir dist
+          mv target/${{ matrix.target }}/release/buildc dist/${{ matrix.artifact_name }}
+      # Upload
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/${{ matrix.artifact_name }}
+  #
+  # release:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - name: Download all artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         path: artifacts
+  #
+  #     - name: Create Release
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         # Create release notes (optional - customize as needed)
+  #         echo "Release notes for version ${GITHUB_REF#refs/tags/}" > release_notes.md
+  #         echo "Automated release for version ${GITHUB_REF#refs/tags/}" >> release_notes.md
+  #
+  #         # Create the release
+  #         gh release create "${GITHUB_REF#refs/tags/}" \
+  #           --title "${GITHUB_REF#refs/tags/}" \
+  #           --notes-file release_notes.md \
+  #           artifacts/*/* \
+  #           --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           # Windows x86_64
           - target: x86_64-pc-windows-gnu
-            os: windows-latest
+            os: ubuntu-latest
             artifact_name: buildc-windows-x64.exe
           # Windows arm64
           - target: aarch64-pc-windows-msvc
-            os: windows-latest
+            os: ubuntu-latest
             artifact_name: buildc-windows-arm64.exe
           # MacOS x86_64
           - target: x86_64-apple-darwin
@@ -43,13 +43,10 @@ jobs:
       - uses: actions/checkout@v4
       - run: git pull
       # Setup
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
       - name: Install cross
         run: cargo install cross
       # Build
-      - name: Build
+      - name: Build (cross)
         run: cross build --release --target ${{ matrix.target }}
       - name: Rename buildc (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   # draft-release:
   #   runs-on: ubuntu-latest
   build:
-    name: Build ${{ matrix.target }}
+    name: Build ${{ matrix.artifact_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -34,6 +34,10 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_name: buildc-linux-x64
+          # Linux arm64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact_name: buildc-linux-arm64
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4
@@ -46,6 +50,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
       # Build
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,8 @@
 name: Release
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-workflow
 
 jobs:
-  # draft-release:
-  #   runs-on: ubuntu-latest
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -38,7 +33,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_name: buildc-linux-arm64
-            cross: true # ARM builds are failing, but work with cross
+            cross: true # ARM builds are failing at the linker step, but works when using cross!
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4
@@ -51,10 +46,10 @@ jobs:
         if: matrix.cross == true
         run: cargo install cross
       # Build
-      - name: Build
+      - name: Build (Native)
         if: matrix.cross != true
         run: cargo build --release --target ${{ matrix.target }}
-      - name: Build
+      - name: Build (Cross)
         if: matrix.cross == true
         run: cross build --release --target ${{ matrix.target }}
       - name: Rename buildc (Windows)
@@ -75,33 +70,3 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: dist/${{ matrix.artifact_name }}
-  #
-  # release:
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: artifacts
-  #     - run: find . -type f -exec sha256sum {} \; > ../SHA256SUMS
-  #       working_directory: artifacts
-  #
-  #     - name: Create Release
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       run: |
-  #         # Create release notes (optional - customize as needed)
-  #         echo "Release notes for version ${GITHUB_REF#refs/tags/}" > release_notes.md
-  #         echo "Automated release for version ${GITHUB_REF#refs/tags/}" >> release_notes.md
-  #
-  #         # Create the release
-  #         gh release create "${GITHUB_REF#refs/tags/}" \
-  #           --title "${GITHUB_REF#refs/tags/}" \
-  #           --notes-file release_notes.md \
-  #           artifacts/** \
-  #           --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,18 @@ jobs:
   # draft-release:
   #   runs-on: ubuntu-latest
   build:
-    name: Build ${{ matrix.artifact_name }}
+    name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           # Windows x86_64
           - target: x86_64-pc-windows-gnu
-            os: ubuntu-latest
+            os: windows-latest
             artifact_name: buildc-windows-x64.exe
           # Windows arm64
-          - target: aarch64-pc-windows-gnu
-            os: ubuntu-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
             artifact_name: buildc-windows-arm64.exe
           # MacOS x86_64
           - target: x86_64-apple-darwin
@@ -34,10 +34,6 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_name: buildc-linux-x64
-          # Linux arm64
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact_name: buildc-linux-arm64
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4
@@ -46,11 +42,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - name: Install cross
-        run: cargo install cross
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
       # Build
-      - name: Build (cross)
-        run: cross build --release --target ${{ matrix.target }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
       - name: Rename buildc (Windows)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,16 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt-get install -y libc6-dev-arm64-cross
       # Build
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: |
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+            export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+          fi
+          cargo build --release --target ${{ matrix.target }}
       - name: Rename buildc (Windows)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_name: buildc-linux-arm64
+            cross: true # ARM builds are failing, but work with cross
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4
@@ -46,9 +47,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Install Cross
+        if: matrix.cross == true
+        run: cargo install cross
       # Build
       - name: Build
+        if: matrix.cross != true
         run: cargo build --release --target ${{ matrix.target }}
+      - name: Build
+        if: matrix.cross == true
+        run: cross build --release --target ${{ matrix.target }}
       - name: Rename buildc (Windows)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
       - uses: actions/checkout@v4
       - run: git pull
       # Setup
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - name: Install cross
         run: cargo install cross
       # Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_name: buildc-linux-x64
+          # Linux arm64
+          # - target: aarch64-unknown-linux-gnu
+          #   os: ubuntu-latest
+          #   artifact_name: buildc-linux-x64
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4
@@ -42,10 +46,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
+      # - name: Install dependencies (Linux)
+      #   if: runner.os == 'Linux'
+      #   run: |
+      #     sudo apt-get update
       # Build
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
             os: ubuntu-latest
             artifact_name: buildc-linux-x64
           # Linux arm64
-          # - target: aarch64-unknown-linux-gnu
-          #   os: ubuntu-latest
-          #   artifact_name: buildc-linux-x64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact_name: buildc-linux-arm64
     steps:
       # Checkout and pull changes from previous jobs
       - uses: actions/checkout@v4
@@ -46,10 +46,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      # - name: Install dependencies (Linux)
-      #   if: runner.os == 'Linux'
-      #   run: |
-      #     sudo apt-get update
       # Build
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       # Build
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,20 +46,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          sudo apt-get install -y libc6-dev-arm64-cross
+      - name: Install cross
+        run: cargo install cross
       # Build
       - name: Build
-        run: |
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
-            export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
-            export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
-          fi
-          cargo build --release --target ${{ matrix.target }}
+        run: cross build --release --target ${{ matrix.target }}
       - name: Rename buildc (Windows)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - release-workflow
 
 jobs:
   # draft-release:
@@ -56,6 +59,7 @@ jobs:
         run: |
           mkdir dist
           mv target/${{ matrix.target }}/release/buildc dist/${{ matrix.artifact_name }}
+      # Signing: TODO
       # Upload
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       # Build
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
@@ -79,6 +79,8 @@ jobs:
   #       uses: actions/download-artifact@v4
   #       with:
   #         path: artifacts
+  #     - run: find . -type f -exec sha256sum {} \; > ../SHA256SUMS
+  #       working_directory: artifacts
   #
   #     - name: Create Release
   #       env:
@@ -92,5 +94,5 @@ jobs:
   #         gh release create "${GITHUB_REF#refs/tags/}" \
   #           --title "${GITHUB_REF#refs/tags/}" \
   #           --notes-file release_notes.md \
-  #           artifacts/*/* \
+  #           artifacts/** \
   #           --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,13 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           mkdir dist
-          mv target/${{ matrix.target }}/release/buildc.exe dist/${{ matrix.artifact_name }}
+          mv target/${{ matrix.target }}/release/aklinker1_buildc.exe dist/${{ matrix.artifact_name }}
         shell: bash
       - name: Rename buildc (Unix)
         if: runner.os != 'Windows'
         run: |
           mkdir dist
-          mv target/${{ matrix.target }}/release/buildc dist/${{ matrix.artifact_name }}
+          mv target/${{ matrix.target }}/release/aklinker1_buildc dist/${{ matrix.artifact_name }}
       # Signing: TODO
       # Upload
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             os: ubuntu-latest
             artifact_name: buildc-windows-x64.exe
           # Windows arm64
-          - target: aarch64-pc-windows-msvc
+          - target: aarch64-pc-windows-gnu
             os: ubuntu-latest
             artifact_name: buildc-windows-arm64.exe
           # MacOS x86_64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ linker = "clang"
 linker = "clang"
 [target.x86_64-unknown-linux-gnu]
 linker = "gcc"
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,3 @@ serde_yaml = "0.9"
 glob = "0.3.1"
 md5 = "0.7.0"
 fs_extra = "1.3.0"
-
-# Cross-compilation for GitHub Actions
-
-[target.x86_64-pc-windows-msvc]
-linker = "lld"
-[target.x86_64-apple-darwin]
-linker = "clang"
-[target.aarch64-apple-darwin]
-linker = "clang"
-[target.x86_64-unknown-linux-gnu]
-linker = "gcc"
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,12 @@ serde_yaml = "0.9"
 glob = "0.3.1"
 md5 = "0.7.0"
 fs_extra = "1.3.0"
+
+[target.x86_64-pc-windows-msvc]
+linker = "lld"
+[target.x86_64-apple-darwin]
+linker = "clang"
+[target.aarch64-apple-darwin]
+linker = "clang"
+[target.x86_64-unknown-linux-gnu]
+linker = "gcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ glob = "0.3.1"
 md5 = "0.7.0"
 fs_extra = "1.3.0"
 
+# Cross-compilation for GitHub Actions
+
 [target.x86_64-pc-windows-msvc]
 linker = "lld"
 [target.x86_64-apple-darwin]

--- a/npm/index.mjs
+++ b/npm/index.mjs
@@ -1,0 +1,1 @@
+console.log("Buildc postinstall not performed");

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@aklinker1/buildc",
+  "description": "Zero config CLI tool for caching and orchestrating builds in monorepos",
+  "version": "2.0.0-alpha1",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aklinker1/buildc"
+  },
+  "homepage": "https://github.com/aklinker1/buildc",
+  "keywords": [
+    "monorepo",
+    "build",
+    "cache"
+  ],
+  "author": {
+    "name": "Aaron Klinker",
+    "email": "aaronklinker1+github@gmail.com"
+  },
+  "license": "MIT",
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "bin": {
+    "buildc": "./index.mjs"
+  }
+}

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -1,0 +1,1 @@
+console.log("postinstall");


### PR DESCRIPTION
Getting ready to release alpha versions of v2, written in rust. This PR sets up the workflow to build and sign.

- [x] Windows x86_64
- [x] Windows arm64
- [x] Generic Linux x86_64
- [x] Generic Linux arm64
- [x] MacOS x86_64 (Intel)
- [x] MacOS arm64 (Apple Silicon - M1, M2, M3, etc)